### PR TITLE
Use unittest from pub.dartlang.org rather than the SDK

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,5 +4,5 @@ description: A cyclic redundancy check calculator for Dart written in pure Dart.
 author: Kai Sellgren <kaisellgren@gmail.com>
 homepage: http://github.com/kaisellgren/CRC32
 dependencies:
-  unittest:
-    sdk: unittest
+  unittest: any
+


### PR DESCRIPTION
Hi -

I'm trying to use the DartZip library, but running into issues with conflicting locations for the unittest library. The current best practice is to use unittest from pub.dartlang.org, so I'd like to get this package updated to do that.

thanks!
Dan
