### PR TITLE
Dart 0.4.1 compatibility

### DIFF
--- a/lib/crc32.dart
+++ b/lib/crc32.dart
@@ -72,7 +72,7 @@ class CRC32 {
     crc = crc ^ (-1);
 
     for (var i = 0, length = input.length; i < length; i++) {
-      var x = CRC32._table[(crc ^ input.charCodeAt(i)) & 0xFF];
+      var x = CRC32._table[(crc ^ input.codeUnitAt(i)) & 0xFF];
 
       crc = (crc & 0xffffffff) >> 8; // crc >>> 8 (32-bit unsigned integer)
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crc32
-version: 0.1.2
+version: 0.1.3
 description: A cyclic redundancy check calculator for Dart written in pure Dart.
 author: Kai Sellgren <kaisellgren@gmail.com>
 homepage: http://github.com/kaisellgren/CRC32

--- a/test/test.dart
+++ b/test/test.dart
@@ -4,6 +4,6 @@ import 'package:crc32/crc32.dart';
 void main() {
 
   test('basic', () {
-    expect(CRC32.compute("testing out".charCodes()), 316532775);
+    expect(CRC32.compute("testing out".codeUnits), 316532775);
   });
 }


### PR DESCRIPTION
There were some breaking API changes in the Dart 0.4.1 release that prevent this module from working in Dart latest. Namely `charCodeAt` and `charCodes` have been renamed to `codeUnitAt` and `codeUnits` respectively.

This PR includes a miner version bump in the pubspec.yaml so once you merge the changes to master all you have to do is run `pub publish` and the world will be a happier CRC32 place again.

Thanks in advance
- Joseph Moniz
