### PR TITLE
fix an analysis issue with the ^ operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.idea/
 /.project
 /pubspec.lock
-packages/
+packages

--- a/lib/crc32.dart
+++ b/lib/crc32.dart
@@ -65,7 +65,7 @@ class CRC32 {
    *
    * You may optionally specify the beginning CRC value.
    */
-  static int compute(var input, [num crc = 0]) {
+  static int compute(var input, [int crc = 0]) {
     if (input is List<int>)
       input = new String.fromCharCodes(input);
 


### PR DESCRIPTION
Fix an analysis issue in the `compute` method. The `^` operator is not defined on `num`, but on `int`:

```
There is no such operator '^' in 'num'
```

Also, tweaked the .gitignore file slightly to ignore the test/packages directory.
