### PR TITLE
Update CRC32 to be compatible with Dart 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
+.dart_tool
 .project
 /pubspec.lock
 .packages

--- a/lib/crc32.dart
+++ b/lib/crc32.dart
@@ -4,7 +4,7 @@
 /// http://www.opensource.org/licenses/mit-license.php
 library crc32;
 
-import 'dart:convert';
+import 'package:dart2_constant/convert.dart' as convert;
 
 /// Computes Cyclic Redundancy Check values.
 class CRC32 {
@@ -15,7 +15,7 @@ class CRC32 {
   /// You may optionally specify the beginning CRC value.
   static int compute(var input, [int crc = 0]) {
     if (input == null) throw new ArgumentError.notNull('input');
-    if (input is String) input = UTF8.encode(input);
+    if (input is String) input = convert.utf8.encode(input);
     if (crc == null) crc = 0;
 
     crc = crc ^ (0xffffffff);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,10 @@ version: 0.1.6
 description: A cyclic redundancy check calculator for Dart written in pure Dart.
 author: Kai Sellgren <kaisellgren@gmail.com>
 homepage: http://github.com/kaisellgren/CRC32
+
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=1.24.3 <3.0.0'
+
 dev_dependencies:
-  test: any
+  dart2_constant: ^1.0.0
+  test: ">=0.12.30 <2.0.0"


### PR DESCRIPTION
# Overview

Update ```CRC32``` to be compatible with Dart 2 

# Testing Suggestions 

- [ ] pub get and tests pass on Dart 1 and Dart 2 

# FYA 

@kaisellgren @rspilker