### PR TITLE
Maintenance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock
+
 .idea/
 .project
-/pubspec.lock
 .packages
 **/packages/
 doc/api/

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This project is a Dart implementation of CRC32.
 ## Examples
 
 ```
-import 'package:crc32/crc32.dart');
+import 'package:crc32/crc32.dart';
 
 void main() {
-  print(CRC32.compute("testing out")); // 316532775 (which in hex format is 12dde827).
+  print(CRC32.computeString('testing out')); // 316532775 (which in hex format is 12dde827).
 }
 ```
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,1 @@
+include: package:lints/recommended.yaml

--- a/example/crc32_example.dart
+++ b/example/crc32_example.dart
@@ -1,0 +1,5 @@
+import 'package:crc32/crc32.dart';
+
+void main() {
+  print(CRC32.computeString('testing out')); // 316532775 (which in hex format is 12dde827).
+}

--- a/lib/crc32.dart
+++ b/lib/crc32.dart
@@ -19,8 +19,9 @@ class CRC32 {
     crc = crc ^ (0xffffffff);
 
     for (final byte in bytes) {
-      if (!(byte >= -128 && byte <= 255)) throw new FormatException(
-          'Invalid value in input: $byte');
+      if (!(byte >= -128 && byte <= 255)) {
+        throw FormatException('Invalid value in input: $byte');
+      }
 
       var x = CRC32._table[(crc ^ byte) & 0xff];
       crc = (crc & 0xffffffff) >> 8; // crc >>> 8 (32-bit unsigned integer)
@@ -33,7 +34,7 @@ class CRC32 {
     return crc & 0xffffffff;
   }
 
-  static const _table = const [
+  static const _table = [
     0x00000000,
     0x77073096,
     0xEE0E612C,

--- a/lib/crc32.dart
+++ b/lib/crc32.dart
@@ -8,21 +8,19 @@ import 'dart:convert';
 
 /// Computes Cyclic Redundancy Check values.
 class CRC32 {
+  static int computeString(String input) => compute(utf8.encode(input));
+
   /// Computes a CRC32 value for the given input.
   ///
   /// The return value is an unsigned integer.
   ///
   /// You may optionally specify the beginning CRC value.
-  static int compute(var input, [int crc = 0]) {
-    if (input == null) throw new ArgumentError.notNull('input');
-    if (input is String) input = UTF8.encode(input);
-    if (crc == null) crc = 0;
-
+  static int compute(List<int> bytes, [int crc = 0]) {
     crc = crc ^ (0xffffffff);
 
-    for (var byte in input) {
+    for (final byte in bytes) {
       if (!(byte >= -128 && byte <= 255)) throw new FormatException(
-          "Invalid value in input: $byte");
+          'Invalid value in input: $byte');
 
       var x = CRC32._table[(crc ^ byte) & 0xff];
       crc = (crc & 0xffffffff) >> 8; // crc >>> 8 (32-bit unsigned integer)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,11 @@
 name: crc32
 version: 0.2.0
 description: A cyclic redundancy check calculator for Dart written in pure Dart.
-homepage: http://github.com/kaisellgren/CRC32
+repository: http://github.com/kaisellgren/CRC32
 
 environment:
   sdk: '>=2.12.0 <4.0.0'
 
 dev_dependencies:
-  test: any
+  lints: ^2.0.0
+  test: ^1.21.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,9 +1,10 @@
 name: crc32
-version: 0.1.6
+version: 0.2.0
 description: A cyclic redundancy check calculator for Dart written in pure Dart.
-author: Kai Sellgren <kaisellgren@gmail.com>
 homepage: http://github.com/kaisellgren/CRC32
+
 environment:
-  sdk: '>=1.0.0 <2.0.0'
+  sdk: '>=2.12.0 <4.0.0'
+
 dev_dependencies:
   test: any

--- a/test/crc32_test.dart
+++ b/test/crc32_test.dart
@@ -6,19 +6,19 @@ import 'package:test/test.dart';
 void main() {
   group("String", () {
     test('empty', () {
-      expect(CRC32.compute(""), 0);
+      expect(CRC32.computeString(""), 0);
     });
 
     test('simple', () {
-      expect(CRC32.compute('hello').toRadixString(16), '3610a686');
+      expect(CRC32.computeString('hello').toRadixString(16), '3610a686');
     });
 
     test('crc32 is positive', () {
-      expect(CRC32.compute('HELLO'), 3242484790);
+      expect(CRC32.computeString('HELLO'), 3242484790);
     });
 
     test('utf8 encoding', () {
-      expect(CRC32.compute('\u{1F336}').toRadixString(16), 'e459f788');
+      expect(CRC32.computeString('\u{1F336}').toRadixString(16), 'e459f788');
     });
   });
 
@@ -37,10 +37,6 @@ void main() {
   });
 
   group("Exceptions", () {
-    test('null input', () {
-      expect(() => CRC32.compute(null), throwsArgumentError);
-    });
-
     test('256', () {
       expect(() => CRC32.compute(<int>[256]), throwsFormatException);
     });


### PR DESCRIPTION
Updated to follow dart 2.12+ standarts.

New static method added `int SRC32.computeString(String)`.

BREAKING CHANGES:
`int SRC32.compute(dynamic, [int?])` -> `int SRC32.compute(List<int>, [int])`